### PR TITLE
Allow FileAppender to work with any object that implements WriteString

### DIFF
--- a/v1/appender.go
+++ b/v1/appender.go
@@ -22,8 +22,12 @@ func FormatLog(log *Log) string {
 		log.Message())
 }
 
+type StringWriter interface {
+	WriteString(s string) (ret int, err error)
+}
+
 type FileAppender struct {
-	*os.File
+	StringWriter
 }
 
 func (self FileAppender) Append(log *Log) error {

--- a/v1/appender.go
+++ b/v1/appender.go
@@ -22,6 +22,7 @@ func FormatLog(log *Log) string {
 		log.Message())
 }
 
+// StringWriter is implemented by *os.File.
 type StringWriter interface {
 	WriteString(s string) (ret int, err error)
 }


### PR DESCRIPTION
This facilitates writing log files that use the proper line endings on Windows.
